### PR TITLE
fix: add _favicon/* to web_accessible_resources to resolve favicon loading error

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -44,7 +44,7 @@ export default defineManifest({
   ],
   web_accessible_resources: [
     {
-      resources: ['*.js', '*.css', 'public/*', '*.png'],
+      resources: ['*.js', '*.css', 'public/*', '*.png', '_favicon/*'],
       matches: ['<all_urls>'],
     },
   ],


### PR DESCRIPTION
## Summary
- Add `_favicon/*` to web_accessible_resources in manifest to fix favicon loading error
- Resolves console error: "Resources must be listed in the web_accessible_resources manifest key"

## Test plan
- [ ] Build extension and test favicon loading
- [ ] Verify no console errors when loading favicons
- [ ] Test on various websites to ensure favicons display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)