### PR TITLE
Fix action command alias bug

### DIFF
--- a/src/services/__tests__/searchService.test.ts
+++ b/src/services/__tests__/searchService.test.ts
@@ -42,6 +42,7 @@ describe('searchService', () => {
       description: 'Close all duplicate tabs',
       alias: ['dup'],
       type: 'action',
+      immediateAlias: true,
     },
   ];
 
@@ -309,6 +310,50 @@ describe('searchService', () => {
         loading: false,
         error: 'Network error',
       });
+    });
+
+    it('should handle action commands without calling search', async () => {
+      const result = await performSearch({
+        query: 'dup',
+        availableCommands: mockCommands,
+        broker: mockBroker,
+      });
+
+      expect(result).toEqual({
+        results: [
+          {
+            id: 'tab.close-duplicates',
+            title: 'Close Duplicate Tabs',
+            description: 'Close all duplicate tabs',
+            icon: undefined,
+            type: 'command',
+            actions: [
+              {
+                id: 'select',
+                label: 'Select',
+                shortcut: 'Enter',
+                primary: true,
+              },
+            ],
+            metadata: {
+              command: {
+                id: 'tab.close-duplicates',
+                name: 'Close Duplicate Tabs',
+                description: 'Close all duplicate tabs',
+                alias: ['dup'],
+                type: 'action',
+                immediateAlias: true,
+              },
+            },
+          },
+        ],
+        loading: false,
+        activeExtension: 'tab',
+        activeCommand: 'close-duplicates',
+      });
+
+      // Should not call search for action commands
+      expect(mockBroker.sendSearchRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -10,6 +10,7 @@ import Fuse from 'fuse.js';
 
 import { BookmarkResultType } from '@/extensions/bookmark/constants';
 import { SearchResultType } from '@/extensions/core/constants';
+import { commandToSearchResult } from '@/extensions/core/search';
 import { HistoryResultType } from '@/extensions/history/constants';
 import { TabResultType } from '@/extensions/tab/constants';
 import { TopSitesResultType } from '@/extensions/topsites/constants';
@@ -162,13 +163,21 @@ export async function performSearch(
 
       if (command) {
         const { extensionId, commandId } = parseCommandId(command.id);
-        const results = await searchExtension(
-          extensionId,
-          commandId,
-          searchTerm,
-          broker
-        );
-        return createSuccessResult(results, extensionId, commandId);
+
+        // Only search if it's a search command
+        if (command.type === 'search') {
+          const results = await searchExtension(
+            extensionId,
+            commandId,
+            searchTerm,
+            broker
+          );
+          return createSuccessResult(results, extensionId, commandId);
+        }
+
+        // For action commands, return the command as a result
+        const actionResult = commandToSearchResult(command);
+        return createSuccessResult([actionResult], extensionId, commandId);
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix bug where action command aliases would incorrectly trigger search requests and fail
- Add proper type checking to differentiate between search and action commands  
- Use `commandToSearchResult` utility for consistent result generation
- Add comprehensive test coverage for action command handling

## Problem

When a user triggered a non-search command alias (like 'dup' for close-duplicates), the system would attempt to call `searchExtension` which would fail because action commands don't have search functionality.

## Solution

- Added command type checking before deciding whether to search or return command result
- For search commands: Continue with existing search logic
- For action commands: Use `commandToSearchResult` to generate proper result structure
- Refactored to use the standardized utility function for consistency

## Test Coverage

- Added test case verifying action commands work without triggering search requests
- Updated mock commands to include proper `immediateAlias` configuration
- Verified correct result structure with actions, metadata, and command details

## Technical Changes

- Modified `performSearch` function in `searchService.ts` to handle both command types
- Imported and utilized `commandToSearchResult` from core extension utilities  
- Enhanced test suite with action command scenario coverage

🤖 Generated with [Claude Code](https://claude.ai/code)